### PR TITLE
StopProcess -command contained also that in frontend.sh it was used. …

### DIFF
--- a/scripts/frontend.sh
+++ b/scripts/frontend.sh
@@ -103,7 +103,6 @@ control_c()
 # run if user hits control-c
 {
   echo -en "\Cancelling\n"
-  send_command "stopProcess"
   exit $?
 }
 


### PR DESCRIPTION
…It's unnecessary yet because we don't have threads in command executing.