### PR TITLE
submit fix to frontend.sh

### DIFF
--- a/scripts/frontend.sh
+++ b/scripts/frontend.sh
@@ -8,8 +8,7 @@ function command_submit () {
     then
     send_command_wait_output "submit path `pwd`"
   else
-    echo "submit path `pwd` exerciseName $1"
-    send_command_wait_output "submit path `pwd` exerciseName $1"
+    send_command_wait_output "submit path `pwd` $1"
   fi
 
   echo "$OUTPUT"


### PR DESCRIPTION
This was already in master but someone fixed it wrong in merge conflict. When user gives --vim flag, this code recognizes it as flag, not exercise name 